### PR TITLE
Fix mintty config dialog in midipix

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1575,6 +1575,10 @@ add_file_resources(control *ctrl, wstring pattern)
   int ok = false;
   for (int i = last_config_dir; i >= 0; i--) {
     wchar * rcpat = path_posix_to_win_w(config_dirs[i]);
+    if (rcpat == NULL) {
+      fprintf(stderr, "could not convert POSIX path '%s' to Windows: %m\n", config_dirs[i]);
+      continue;
+    }
     int len = wcslen(rcpat);
     rcpat = renewn(rcpat, len + wcslen(pattern) + 2);
     rcpat[len++] = L'/';

--- a/src/windialog.c
+++ b/src/windialog.c
@@ -704,7 +704,12 @@ win_open_config(void)
 
   static bool initialised = false;
   if (!initialised) {
-    InitCommonControls();
+    INITCOMMONCONTROLSEX ccex;
+    ccex.dwSize = sizeof(ccex);
+    ccex.dwICC = ICC_TREEVIEW_CLASSES;
+    if (!InitCommonControlsEx(&ccex)) {
+      fprintf(stderr, "InitCommonControlsEx failed: 0x%x\n", GetLastError());
+    }
     RegisterClassW(&(WNDCLASSW){
       .lpszClassName = W(DIALOG_CLASS),
       .lpfnWndProc = DefDlgProcW,


### PR DESCRIPTION
This fixes two bugs: failure to initialize any controls in the config dialog, and a crash when directories potentially used for mintty resources, such as /usr/share, do not exist.